### PR TITLE
Initial CMake and Visual Studio 2017 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 *.exe
 *.out
 *.app
+
+# CMake outputs
+cmake/*/

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@
 
 # CMake outputs
 cmake/*/
+
+# Visual Studio generated files
+.vs/*
+CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required (VERSION 3.7) # it may work with older versions but that needs to be tested.
+
+project (Base)
+
+# These following lines are passed through @varname@ blocks when using `configure_file` to generate
+# new files.
+set (Base_VERSION_MAJOR 1)
+set (Base_VERSION_MINOR 0)
+
+file (GLOB SRCS *.cpp)  # alternatively we could "set ( SRCS filea fileb filec )"
+file (GLOB HDRS *.hpp)
+
+source_group("Source Files" FILES ${SRCS} ${HDRS})
+
+include_directories(${CMAKE_SOURCE_DIR}/..) # all #includes are <Base/...>
+add_library (Base STATIC ${SRCS} ${HDRS})
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,16 @@ include_directories (${INCDIRS})
 add_library (Base STATIC ${SRCS} ${HDRS} ${INTSRC})
 target_include_directories (Base PUBLIC ${INCDIRS})
 
-# Required for VS2017 & C++17 (<optional> is unavailable until C++17 in MSVC)
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    # Required for VS2017 & C++17 (<optional> is unavailable until C++17 in MSVC)
+    target_compile_options (Base PRIVATE "/std:c++latest")
+    set_property (TARGET Base PROPERTY CXX_STANDARD 17)
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    set_property (TARGET Base PROPERTY CXX_STANDARD 14)
+endif (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+
+# auto_ptr is removed in C++17 so prevent its usage in Boost
 target_compile_definitions (Base PRIVATE BOOST_NO_AUTO_PTR)
-target_compile_options (Base PRIVATE "/std:c++latest")
-set_property (TARGET Base PROPERTY CXX_STANDARD 17)
 set_property (TARGET Base PROPERTY CXX_STANDARD_REQUIRED ON)
 
 # Make the Tests dir included when building

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,13 @@ set (Base_VERSION_MINOR 0)
 file (GLOB SRCS *.cpp)  # alternatively we could "set ( SRCS filea fileb filec )"
 file (GLOB HDRS *.hpp)
 
+file (GLOB INTSRC Internal/*)
+
 source_group("Source Files" FILES ${SRCS} ${HDRS})
+source_group("Source Files\\Internal" FILES ${INTSRC})
 
 include_directories(${CMAKE_SOURCE_DIR}/..) # all #includes are <Base/...>
-add_library (Base STATIC ${SRCS} ${HDRS})
-
+add_library (Base STATIC ${SRCS} ${HDRS} ${INTSRC})
+target_include_directories(Base PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..) # all #includes are <Base/...>
+add_subdirectory (Tests)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,5 +18,7 @@ source_group("Source Files\\Internal" FILES ${INTSRC})
 include_directories(${CMAKE_SOURCE_DIR}/..) # all #includes are <Base/...>
 add_library (Base STATIC ${SRCS} ${HDRS} ${INTSRC})
 target_include_directories(Base PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..) # all #includes are <Base/...>
+set_property(TARGET Base PROPERTY CXX_STANDARD 14)
+set_property(TARGET Base PROPERTY CXX_STANDARD_REQUIRED ON)
 add_subdirectory (Tests)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.7) # it may work with older versions but that needs to be tested.
+cmake_minimum_required (VERSION 3.6) # it may work with older versions but that needs to be tested.
 
 project (Base)
 
@@ -16,9 +16,12 @@ source_group("Source Files" FILES ${SRCS} ${HDRS})
 source_group("Source Files\\Internal" FILES ${INTSRC})
 
 include_directories(${CMAKE_SOURCE_DIR}/..) # all #includes are <Base/...>
+
 add_library (Base STATIC ${SRCS} ${HDRS} ${INTSRC})
 target_include_directories(Base PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..) # all #includes are <Base/...>
-set_property(TARGET Base PROPERTY CXX_STANDARD 14)
+target_compile_options(Base PRIVATE "/std:c++latest")
+set_property(TARGET Base PROPERTY CXX_STANDARD 17)
 set_property(TARGET Base PROPERTY CXX_STANDARD_REQUIRED ON)
+
 add_subdirectory (Tests)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,40 @@
-cmake_minimum_required (VERSION 3.6) # it may work with older versions but that needs to be tested.
+cmake_minimum_required (VERSION 3.6) # it may work with older versions but that would need to be tested.
 
 project (Base)
 
-# These following lines are passed through @varname@ blocks when using `configure_file` to generate
-# new files.
+# These following lines are passed through @varname@ blocks when using `configure_file` to generate new files.
 set (Base_VERSION_MAJOR 1)
 set (Base_VERSION_MINOR 0)
+
+set (VENDOR_DIR ${CMAKE_SOURCE_DIR}/Vendor)
 
 file (GLOB SRCS *.cpp)  # alternatively we could "set ( SRCS filea fileb filec )"
 file (GLOB HDRS *.hpp)
 
+source_group ("Source Files" FILES ${SRCS} ${HDRS})
+
 file (GLOB INTSRC Internal/*)
+source_group ("Source Files\\Internal" FILES ${INTSRC})
 
-source_group("Source Files" FILES ${SRCS} ${HDRS})
-source_group("Source Files\\Internal" FILES ${INTSRC})
+file (GLOB_RECURSE VENDORFILES Vendor/*.[chpp] Vendor/*.[ch])
+source_group ("Vendor Files" FILES ${VENDORFILES})
 
-include_directories(${CMAKE_SOURCE_DIR}/..) # all #includes are <Base/...>
+set (INCDIRS
+     ${CMAKE_SOURCE_DIR}/.. # all includes are <Base/...>
+     ${VENDOR_DIR}/utf8rewind/include
+     ${VENDOR_DIR}/boost
+     )
+include_directories (${INCDIRS})
 
 add_library (Base STATIC ${SRCS} ${HDRS} ${INTSRC})
-target_include_directories(Base PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..) # all #includes are <Base/...>
-target_compile_options(Base PRIVATE "/std:c++latest")
-set_property(TARGET Base PROPERTY CXX_STANDARD 17)
-set_property(TARGET Base PROPERTY CXX_STANDARD_REQUIRED ON)
+target_include_directories (Base PUBLIC ${INCDIRS})
 
+# Required for VS2017 & C++17 (<optional> is unavailable until C++17 in MSVC)
+target_compile_definitions (Base PRIVATE BOOST_NO_AUTO_PTR)
+target_compile_options (Base PRIVATE "/std:c++latest")
+set_property (TARGET Base PROPERTY CXX_STANDARD 17)
+set_property (TARGET Base PROPERTY CXX_STANDARD_REQUIRED ON)
+
+# Make the Tests dir included when building
 add_subdirectory (Tests)
 

--- a/Exception.hpp
+++ b/Exception.hpp
@@ -24,6 +24,7 @@
 #include <Base/Types.hpp>
 
 #include <boost/scope_exit.hpp>
+#include <cstdarg>
 #include <stdexcept>
 
 // -- Macros

--- a/GeneratedObjectCode.hpp
+++ b/GeneratedObjectCode.hpp
@@ -37,18 +37,18 @@ class DescriberState;
 
 // -- Macros
 
-#define NXA_STR_VALUE_FOR(arg...) #arg
+#define NXA_STR_VALUE_FOR(arg) #arg
 
 #define NXA_GENERATED_INTERNAL_OBJECT_FORWARD_DECLARATION() \
         protected: \
             struct Internal; \
         private:
 
-#define NXA_GENERATED_INTERNAL_OBJECT_FORWARD_DECLARATION_USING(class_name...) \
+#define NXA_GENERATED_INTERNAL_OBJECT_FORWARD_DECLARATION_USING(class_name) \
         private:\
             using Internal = class_name; \
 
-#define NXA_GENERATED_INTERNAL_OBJECT_NAME_AND_HASH_METHODS_DECLARATIONS_FOR(class_name...) \
+#define NXA_GENERATED_INTERNAL_OBJECT_NAME_AND_HASH_METHODS_DECLARATIONS_FOR(class_name) \
         virtual uinteger32 classHash() const override \
         { \
             static uinteger32 result = String::hashFor(this->className()); \
@@ -59,7 +59,7 @@ class DescriberState;
             return NXA_STR_VALUE_FOR(class_name); \
         }
 
-#define NXA_GENERATED_COMMON_OBJECT_METHODS_DECLARATIONS_WITHOUT_INTERNAL_OBJECT_FOR(class_name...) \
+#define NXA_GENERATED_COMMON_OBJECT_METHODS_DECLARATIONS_WITHOUT_INTERNAL_OBJECT_FOR(class_name) \
         protected: \
             class_name(std::shared_ptr<Internal>&&); \
             friend WeakReference<class_name>; \
@@ -86,31 +86,31 @@ class DescriberState;
             String description() const; \
         private:
 
-#define NXA_GENERATED_UNIQUE_OBJECT_METHODS_DECLARATIONS_WITHOUT_INTERNAL_OBJECT_FOR(class_name...) \
+#define NXA_GENERATED_UNIQUE_OBJECT_METHODS_DECLARATIONS_WITHOUT_INTERNAL_OBJECT_FOR(class_name) \
         public: \
             class_name(const class_name&) = delete; \
         NXA_GENERATED_COMMON_OBJECT_METHODS_DECLARATIONS_WITHOUT_INTERNAL_OBJECT_FOR(class_name) \
 
-#define NXA_GENERATED_UNIQUE_OBJECT_METHODS_DECLARATIONS_FOR(class_name...) \
+#define NXA_GENERATED_UNIQUE_OBJECT_METHODS_DECLARATIONS_FOR(class_name) \
         protected: \
             std::shared_ptr<Internal> internal; \
         public: \
             class_name(const class_name&) = delete; \
         NXA_GENERATED_COMMON_OBJECT_METHODS_DECLARATIONS_WITHOUT_INTERNAL_OBJECT_FOR(class_name)
 
-#define NXA_GENERATED_OBJECT_METHODS_DECLARATIONS_WITHOUT_INTERNAL_OBJECT_FOR(class_name...) \
+#define NXA_GENERATED_OBJECT_METHODS_DECLARATIONS_WITHOUT_INTERNAL_OBJECT_FOR(class_name) \
         public: \
             class_name(const class_name&); \
         NXA_GENERATED_COMMON_OBJECT_METHODS_DECLARATIONS_WITHOUT_INTERNAL_OBJECT_FOR(class_name) \
 
-#define NXA_GENERATED_OBJECT_METHODS_DECLARATIONS_FOR(class_name...) \
+#define NXA_GENERATED_OBJECT_METHODS_DECLARATIONS_FOR(class_name) \
         protected: \
             std::shared_ptr<Internal> internal; \
         public: \
             class_name(const class_name&); \
         NXA_GENERATED_COMMON_OBJECT_METHODS_DECLARATIONS_WITHOUT_INTERNAL_OBJECT_FOR(class_name)
 
-#define NXA_GENERATED_COMMON_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal_location, class_name...) \
+#define NXA_GENERATED_COMMON_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal_location, class_name) \
         class_name::class_name(class_name&&) = default; \
         class_name::class_name(class_name&) = default; \
         class_name::class_name(std::shared_ptr<Internal>&& other) : internal_location{ std::move(other) } { } \
@@ -142,36 +142,36 @@ class DescriberState;
             return this->description(state); \
         }
 
-#define NXA_GENERATED_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal_location, class_name...) \
+#define NXA_GENERATED_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal_location, class_name) \
         class_name::class_name(const class_name& other) : internal_location{ std::make_shared<Internal>(static_cast<class_name::Internal&>(*other.internal)) } { } \
         NXA_GENERATED_COMMON_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal_location, class_name)
 
-#define NXA_GENERATED_IMMUTABLE_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal_location, class_name...) \
+#define NXA_GENERATED_IMMUTABLE_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal_location, class_name) \
         class_name::class_name(const class_name&) = default; \
         NXA_GENERATED_COMMON_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal_location, class_name)
 
-#define NXA_GENERATED_UNIQUE_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal_location, class_name...) \
+#define NXA_GENERATED_UNIQUE_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal_location, class_name) \
         NXA_GENERATED_COMMON_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal_location, class_name)
 
-#define NXA_GENERATED_OBJECT_METHODS_DEFINITIONS_FOR(class_name...) \
+#define NXA_GENERATED_OBJECT_METHODS_DEFINITIONS_FOR(class_name) \
         class_name::class_name(const class_name& other) : internal{ std::make_shared<Internal>(*other.internal) } { } \
         NXA_GENERATED_COMMON_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal, class_name)
 
-#define NXA_GENERATED_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR_CLASS_WITH_PURE_VIRTUAL_INTERNAL(internal_location, class_name...) \
+#define NXA_GENERATED_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR_CLASS_WITH_PURE_VIRTUAL_INTERNAL(internal_location, class_name) \
         NXA_GENERATED_COMMON_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal_location, class_name)
 
-#define NXA_GENERATED_OBJECT_METHODS_DEFINITIONS_FOR_CLASS_WITH_PURE_VIRTUAL_INTERNAL(class_name...) \
+#define NXA_GENERATED_OBJECT_METHODS_DEFINITIONS_FOR_CLASS_WITH_PURE_VIRTUAL_INTERNAL(class_name) \
         class_name::class_name(const class_name& other) : internal{ other.internal->baseInternalSharedPointer() } { } \
         NXA_GENERATED_COMMON_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal, class_name)
 
-#define NXA_GENERATED_IMMUTABLE_OBJECT_METHODS_DEFINITIONS_FOR(class_name...) \
+#define NXA_GENERATED_IMMUTABLE_OBJECT_METHODS_DEFINITIONS_FOR(class_name) \
         class_name::class_name(const class_name&) = default; \
         NXA_GENERATED_COMMON_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal, class_name)
 
-#define NXA_GENERATED_UNIQUE_OBJECT_METHODS_DEFINITIONS_FOR(class_name...) \
+#define NXA_GENERATED_UNIQUE_OBJECT_METHODS_DEFINITIONS_FOR(class_name) \
         NXA_GENERATED_COMMON_OBJECT_METHODS_DEFINITIONS_WITH_INTERNAL_STORED_IN_FOR(internal, class_name)
 
-#define NXA_GENERATED_INTERNAL_OBJECT_BASE_INTERNAL_SHARED_POINTER_DEFINITION_FOR_BASE_CLASS(class_name...) \
+#define NXA_GENERATED_INTERNAL_OBJECT_BASE_INTERNAL_SHARED_POINTER_DEFINITION_FOR_BASE_CLASS(class_name) \
         virtual std::shared_ptr<class_name> baseInternalSharedPointer() override \
         { \
             return std::static_pointer_cast<class_name>(std::make_shared<Internal>(*this)); \
@@ -180,7 +180,7 @@ class DescriberState;
 #define NXA_GENERATED_INTERNAL_OBJECT_BASE_INTERNAL_SHARED_POINTER_PURE_VIRTUAL_DEFINITION() \
         virtual std::shared_ptr<Internal> baseInternalSharedPointer() = 0;
 
-#define NXA_GENERATED_INTERNAL_OBJECT_BASE_INTERNAL_SHARED_POINTER_DEFINITION_FOR(class_name...) \
+#define NXA_GENERATED_INTERNAL_OBJECT_BASE_INTERNAL_SHARED_POINTER_DEFINITION_FOR(class_name) \
         virtual std::shared_ptr<class_name> baseInternalSharedPointer() \
         { \
             return std::static_pointer_cast<class_name>(std::make_shared<Internal>(*this)); \

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,19 +1,23 @@
-cmake_minimum_required (VERSION 3.6) # it may work with older versions but that needs to be tested.
+cmake_minimum_required (VERSION 3.6) # it may work with older versions but that would need to be tested.
 
 project (BaseTest)
 
-# These following lines are passed through @varname@ blocks when using `configure_file` to generate
-# new files.
+# These following lines are passed through @varname@ blocks when using `configure_file` to generate new files.
 set (BaseTest_VERSION_MAJOR 1)
 set (BaseTest_VERSION_MINOR 0)
 
 file (GLOB SRCS *.cpp *.hpp)
 
-source_group("Source Files" FILES ${SRCS})
+source_group ("Source Files" FILES ${SRCS})
 
-include_directories(${Base_SOURCE_DIR}/..) # all #includes are <Base/...>
+include_directories (${Base_SOURCE_DIR}/..) # all #includes are <Base/...>
 add_executable (BaseTest ${SRCS})
-set_property(TARGET BaseTest PROPERTY CXX_STANDARD 17)
-set_property(TARGET BaseTest PROPERTY CXX_STANDARD_REQUIRED ON)
+
+# C++17/MSVC2017 requirements
+target_compile_options (BaseTest PRIVATE "/std:c++latest")
+set_property (TARGET BaseTest PROPERTY CXX_STANDARD 17)
+set_property (TARGET BaseTest PROPERTY CXX_STANDARD_REQUIRED ON)
+
+# Link to the Base project
 target_link_libraries (BaseTest LINK_PUBLIC Base)
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -13,9 +13,14 @@ source_group ("Source Files" FILES ${SRCS})
 include_directories (${Base_SOURCE_DIR}/..) # all #includes are <Base/...>
 add_executable (BaseTest ${SRCS})
 
-# C++17/MSVC2017 requirements
-target_compile_options (BaseTest PRIVATE "/std:c++latest")
-set_property (TARGET BaseTest PROPERTY CXX_STANDARD 17)
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    # C++17/MSVC2017 requirements
+    target_compile_options (BaseTest PRIVATE "/std:c++latest")
+    set_property (TARGET BaseTest PROPERTY CXX_STANDARD 17)
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    set_property (TARGET BaseTest PROPERTY CXX_STANDARD 14)
+endif (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+
 set_property (TARGET BaseTest PROPERTY CXX_STANDARD_REQUIRED ON)
 
 # Link to the Base project

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required (VERSION 3.7) # it may work with older versions but that needs to be tested.
+
+project (BaseTest)
+
+# These following lines are passed through @varname@ blocks when using `configure_file` to generate
+# new files.
+set (BaseTest_VERSION_MAJOR 1)
+set (BaseTest_VERSION_MINOR 0)
+
+file (GLOB SRCS *.cpp *.hpp)
+
+source_group("Source Files" FILES ${SRCS})
+
+include_directories(${Base_SOURCE_DIR}/..) # all #includes are <Base/...>
+add_executable (BaseTest ${SRCS})
+target_link_libraries (BaseTest LINK_PUBLIC Base)
+

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -13,5 +13,7 @@ source_group("Source Files" FILES ${SRCS})
 
 include_directories(${Base_SOURCE_DIR}/..) # all #includes are <Base/...>
 add_executable (BaseTest ${SRCS})
+set_property(TARGET BaseTest PROPERTY CXX_STANDARD 17)
+set_property(TARGET BaseTest PROPERTY CXX_STANDARD_REQUIRED ON)
 target_link_libraries (BaseTest LINK_PUBLIC Base)
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.7) # it may work with older versions but that needs to be tested.
+cmake_minimum_required (VERSION 3.6) # it may work with older versions but that needs to be tested.
 
 project (BaseTest)
 

--- a/Types.hpp
+++ b/Types.hpp
@@ -27,7 +27,7 @@
 #include <cstdint>
 #include <memory>
 #include <typeinfo>
-#include <experimental/optional>
+#include <optional>
 
 namespace NxA {
 
@@ -57,11 +57,11 @@ using decimal2 = dec::decimal<2>;
 using decimal3 = dec::decimal<3>;
 using decimal = decimal3;
 
-// -- Provide an optional type based on std::experimental::optional. TODO: change to std::optional in C++1y
+// -- Provide an optional type based on std::optional.
 template <typename T>
-using Optional = std::experimental::optional<T>;
-using NullOptional = std::experimental::nullopt_t;
-constexpr NullOptional nothing{0};
+using Optional = std::optional<T>;
+using NullOptional = std::nullopt_t;
+constexpr NullOptional nothing{std::nullopt};
 template <typename T>
 inline constexpr Optional<typename std::decay<T>::type>
 makeOptional(T&& v) {

--- a/Types.hpp
+++ b/Types.hpp
@@ -91,7 +91,7 @@ struct TypeName<Optional<T>> {
 };
 
 // -- Specialization for each type we support.
-#define NXA_STR_VALUE_FOR_TYPE(arg...) #arg
+#define NXA_STR_VALUE_FOR_TYPE(arg) #arg
 
 #define NXA_SPECIALIZE_TYPENAME_FOR_TYPE(name) \
 template <> struct TypeName<name> \

--- a/cmake/make_vs_sln.bat
+++ b/cmake/make_vs_sln.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+cd /d %~dp0
+
+pushd ..
+set SRC_DIR="%CD%"
+popd
+
+call :Create win32 "Visual Studio 14 2015"
+call :Create win64 "Visual Studio 14 2015 Win64"
+goto :eof
+
+:Create
+    set OUTDIR="%~1"
+    set TARGET="%~2"
+    if not exist %OUTDIR% mkdir %OUTDIR%
+    pushd %OUTDIR%
+    cmake -G %TARGET% %SRC_DIR%
+    popd
+    goto :eof

--- a/cmake/make_vs_sln.bat
+++ b/cmake/make_vs_sln.bat
@@ -6,8 +6,8 @@ pushd ..
 set SRC_DIR="%CD%"
 popd
 
-call :Create win32 "Visual Studio 14 2015"
-call :Create win64 "Visual Studio 14 2015 Win64"
+call :Create win32 "Visual Studio 15 2017"
+call :Create win64 "Visual Studio 15 2017 Win64"
 goto :eof
 
 :Create

--- a/cmake/make_xcodeproj
+++ b/cmake/make_xcodeproj
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-pushd ..
+pushd .. > /dev/null
 SRC_DIR=`pwd`
-popd
+popd > /dev/null
 
 mkdir -p xcode
-pushd xcode
+pushd xcode > /dev/null
 cmake -G Xcode "${SRC_DIR}"
-popd
+popd > /dev/null

--- a/cmake/make_xcodeproj
+++ b/cmake/make_xcodeproj
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+pushd ..
+SRC_DIR=`pwd`
+popd
+
+mkdir -p xcode
+pushd xcode
+cmake -G Xcode "${SRC_DIR}"
+popd

--- a/cmake/make_xcodeproj
+++ b/cmake/make_xcodeproj
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd `dirname $0`
+
 pushd .. > /dev/null
 SRC_DIR=`pwd`
 popd > /dev/null


### PR DESCRIPTION
I hope this is in a decent format for this; the changes surrounding std::optional (which isn't 'experimental' in Visual Studio) break the Darwin build but I'm not sure how to exclude that from the PR. The `...` args in the `#define`s also were causing VS to choke but they seemed unnecessary since they were never used as varargs.